### PR TITLE
Phone connected/disconnected alert

### DIFF
--- a/app/src/main/java/com/edotassi/amazmod/Constants.java
+++ b/app/src/main/java/com/edotassi/amazmod/Constants.java
@@ -25,6 +25,7 @@ public class Constants {
     public static final String PREF_FORCE_ENGLISH = "preference.force.english";
     public static final String PREF_DISABLE_NOTIFICATIONS_SCREENON = "preference.amazmodservice.disable.screenon";
     public static final String PREF_DISABLE_STANDARD_NOTIFICATIONS = "preference.disable.standard.notifications";
+    public static final String PREF_PHONE_CONNECT_DISCONNECT_ALERT_= "preference.phone.connect.disconnect.alert";
 
     public static final String PREF_DEFAULT_NOTIFICATIONS_REPLIES = "[]";
     public static final String PREF_DEFAULT_NOTIFICATIONS_VIBRATION = "300";
@@ -40,6 +41,7 @@ public class Constants {
     public static final boolean PREF_DEFAULT_ENABLE_PERSISTENT_NOTIFICATION = true;
     public static final boolean PREF_DEFAULT_DISABLE_NOTIFICATIONS_SCREENON = false;
     public static final boolean PREF_DEFAULT_DISABLE_STANDARD_NOTIFICATIONS = false;
+    public static final boolean PREF_DEFAULT_PHONE_CONNECT_DISCONNECT_ALERT_= false;
 
     public static final int REQUEST_CODE_INTRO = 1;
 

--- a/app/src/main/java/com/edotassi/amazmod/receiver/WatchfaceReceiver.java
+++ b/app/src/main/java/com/edotassi/amazmod/receiver/WatchfaceReceiver.java
@@ -109,7 +109,8 @@ public class WatchfaceReceiver extends BroadcastReceiver {
             PendingIntent pendingIntent = PendingIntent.getBroadcast(context, 0, alarmWatchfaceIntent, 0);
 
             try {
-                alarmManager.setRepeating(AlarmManager.ELAPSED_REALTIME_WAKEUP, SystemClock.elapsedRealtime() + delay,
+                if(alarmManager!=null)
+                    alarmManager.setRepeating(AlarmManager.ELAPSED_REALTIME_WAKEUP, SystemClock.elapsedRealtime() + delay,
                         (long) syncInterval * 60000L, pendingIntent);
             } catch (NullPointerException e) {
                 Log.e(Constants.TAG, "WatchfaceDataReceiver setRepeating exception: " + e.toString());
@@ -119,7 +120,8 @@ public class WatchfaceReceiver extends BroadcastReceiver {
                 AlarmManager alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
                 Intent alarmWatchfaceIntent = new Intent(context, WatchfaceReceiver.class);
                 PendingIntent pendingIntent = PendingIntent.getBroadcast(context, 0, alarmWatchfaceIntent, 0);
-                alarmManager.cancel(pendingIntent);
+                if(alarmManager!=null)
+                    alarmManager.cancel(pendingIntent);
             } catch (NoSuchMethodError e) {
                 e.printStackTrace();
             }
@@ -149,16 +151,19 @@ public class WatchfaceReceiver extends BroadcastReceiver {
     public int getPhoneBattery(Context context){
         IntentFilter ifilter = new IntentFilter(Intent.ACTION_BATTERY_CHANGED);
         Intent batteryStatus = context.registerReceiver(null, ifilter);
-        int status = batteryStatus.getIntExtra(BatteryManager.EXTRA_STATUS, -1);
-        boolean isCharging = status == BatteryManager.BATTERY_STATUS_CHARGING || status == BatteryManager.BATTERY_STATUS_FULL;
-        int chargePlug = batteryStatus.getIntExtra(BatteryManager.EXTRA_PLUGGED, -1);
-        boolean usbCharge = chargePlug == BatteryManager.BATTERY_PLUGGED_USB;
-        boolean acCharge = chargePlug == BatteryManager.BATTERY_PLUGGED_AC;
-        int level = batteryStatus.getIntExtra(BatteryManager.EXTRA_LEVEL, -1);
-        int scale = batteryStatus.getIntExtra(BatteryManager.EXTRA_SCALE, -1);
-
-        float batteryPct = level / (float) scale;
-
+        float batteryPct;
+        if(batteryStatus!=null) {
+            //int status = batteryStatus.getIntExtra(BatteryManager.EXTRA_STATUS, -1);
+            //boolean isCharging = status == BatteryManager.BATTERY_STATUS_CHARGING || status == BatteryManager.BATTERY_STATUS_FULL;
+            //int chargePlug = batteryStatus.getIntExtra(BatteryManager.EXTRA_PLUGGED, -1);
+            //boolean usbCharge = chargePlug == BatteryManager.BATTERY_PLUGGED_USB;
+            //boolean acCharge = chargePlug == BatteryManager.BATTERY_PLUGGED_AC;
+            int level = batteryStatus.getIntExtra(BatteryManager.EXTRA_LEVEL, -1);
+            int scale = batteryStatus.getIntExtra(BatteryManager.EXTRA_SCALE, -1);
+            batteryPct = level / (float) scale;
+        }else{
+            batteryPct = 0;
+        }
         return (int) (batteryPct * 100);
     }
 
@@ -167,8 +172,8 @@ public class WatchfaceReceiver extends BroadcastReceiver {
         String nextAlarm = "--";
         try {
             AlarmManager am = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
-            nextAlarm = am.getNextAlarmClock().toString();
-        } catch (NoSuchMethodError e) {
+            nextAlarm = (am==null)?"--":am.getNextAlarmClock().toString();
+        } catch (Exception e) {
             e.printStackTrace();
         }
 

--- a/app/src/main/java/com/edotassi/amazmod/receiver/WatchfaceReceiver.java
+++ b/app/src/main/java/com/edotassi/amazmod/receiver/WatchfaceReceiver.java
@@ -22,6 +22,7 @@ import com.google.android.gms.tasks.Continuation;
 import com.google.android.gms.tasks.Task;
 import com.pixplicity.easyprefs.library.Prefs;
 
+import java.text.SimpleDateFormat;
 import java.util.Date;
 
 import amazmod.com.transport.data.WatchfaceData;
@@ -168,14 +169,33 @@ public class WatchfaceReceiver extends BroadcastReceiver {
     }
 
     public String getPhoneAlarm(Context context){
-        //String nextAlarm = Settings.System.getString(context.getContentResolver(), Settings.System.NEXT_ALARM_FORMATTED);
         String nextAlarm = "--";
+
         try {
-            AlarmManager am = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
-            nextAlarm = (am==null)?"--":am.getNextAlarmClock().toString();
+            nextAlarm = Settings.System.getString(context.getContentResolver(), Settings.System.NEXT_ALARM_FORMATTED);
+
+            if(nextAlarm.equals("")){
+                nextAlarm = "--";
+            }
+            Log.d(Constants.TAG, "WatchfaceDataReceiver next alarm: "+nextAlarm);
         } catch (Exception e) {
             e.printStackTrace();
         }
+
+        // This is the proper way but the time is given in UTC
+        /*
+        try {
+            AlarmManager am = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
+            if(am!=null && am.getNextAlarmClock()!=null){
+                Long alarmTime = am.getNextAlarmClock().getTriggerTime();
+                SimpleDateFormat sdfDate = new SimpleDateFormat("eee HH:mm");
+                nextAlarm = sdfDate.format(new Date(alarmTime));
+            }
+            Log.d(Constants.TAG, "WatchfaceDataReceiver next alarm: "+nextAlarm);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        */
 
         return nextAlarm;
     }

--- a/app/src/main/java/com/edotassi/amazmod/ui/SettingsActivity.java
+++ b/app/src/main/java/com/edotassi/amazmod/ui/SettingsActivity.java
@@ -98,6 +98,8 @@ public class SettingsActivity extends AppCompatActivity {
                 Constants.PREF_DEFAULT_NOTIFICATIONS_FONT_SIZE);
         final boolean disableNotificationsScreenOn = Prefs.getBoolean(Constants.PREF_DISABLE_NOTIFICATIONS_SCREENON,
                 Constants.PREF_DEFAULT_DISABLE_NOTIFICATIONS_SCREENON);
+        final boolean phoneConnection = Prefs.getBoolean(Constants.PREF_PHONE_CONNECT_DISCONNECT_ALERT_,
+                Constants.PREF_DEFAULT_PHONE_CONNECT_DISCONNECT_ALERT_);
 
         final boolean disableBatteryChartOnDestroy = Prefs.getBoolean(Constants.PREF_DISABLE_BATTERY_CHART,
                 Constants.PREF_DEFAULT_DISABLE_BATTERY_CHART);
@@ -145,6 +147,7 @@ public class SettingsActivity extends AppCompatActivity {
         settingsData.setInvertedTheme(enableInvertedTheme);
         settingsData.setFontSize(fontSize);
         settingsData.setDisableNotificationScreenOn(disableNotificationsScreenOn);
+        settingsData.setPhoneConnectionAlert(phoneConnection);
 
         Watch.get().syncSettings(settingsData).continueWith(new Continuation<Void, Object>() {
             @Override

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -126,6 +126,8 @@
     <string name="pref_filters">Notifications filters</string>
     <string name="pref_enable_music_control_with_hardware_button">Enable hardware music control</string>
     <string name="pref_enable_music_control_with_hardware_button_summary">(EXPERIMENTAL!) Enable music control with hardware key. Press bottom button to play/pause music. Long press to skip next song.</string>
+    <string name="pref_phone_connect_disconnect_alert">Alert when phone connects/disconnects</string>
+    <string name="pref_phone_connect_disconnect_alert_summary">Watch will vibrate and show phone\'s connection status when connects/disconnects</string>
 
     <string name="intro_title_1">Welcome to AmazMod!</string>
     <string name="intro_description_1">Please follow this presentation to learn how to install the service app on watch and grant app access to Notifications on phone.</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -187,6 +187,11 @@
             android:title="@string/pref_enable_music_control_with_hardware_button"
             android:summary="@string/pref_enable_music_control_with_hardware_button_summary" />
         <SwitchPreference
+            android:defaultValue="false"
+            android:key="preference.phone.connect.disconnect.alert"
+            android:title="@string/pref_phone_connect_disconnect_alert"
+            android:summary="@string/pref_phone_connect_disconnect_alert_summary" />
+        <SwitchPreference
             android:defaultValue="true"
             android:key="preference.enable.persistent.notification"
             android:summary="@string/pref_enable_persistent_notification_summary"

--- a/service/src/main/AndroidManifest.xml
+++ b/service/src/main/AndroidManifest.xml
@@ -36,6 +36,14 @@
             android:taskAffinity=""
             android:theme="@style/Theme.Transparent">
         </activity>
+        <activity
+            android:name=".ui.PhoneConnectionActivity"
+            android:allowEmbedded="true"
+            android:exported="true"
+            android:label=""
+            android:taskAffinity=""
+            android:theme="@style/Theme.Transparent">
+        </activity>
         <activity android:name=".ui.RepliesActivity" />
 
         <service android:name="xiaofei.library.hermes.HermesService$HermesService0" />

--- a/service/src/main/AndroidManifest.xml
+++ b/service/src/main/AndroidManifest.xml
@@ -91,5 +91,19 @@
         <meta-data
             android:name="com.google.android.wearable.standalone"
             android:value="true" />
+
+        <receiver
+            android:name=".AdminReceiver"
+            android:label="@string/device_admin"
+            android:description="@string/device_admin_description"
+            android:permission="android.permission.BIND_DEVICE_ADMIN">
+            <meta-data
+                android:name="android.app.device_admin"
+                android:resource="@xml/device_admin" />
+            <intent-filter>
+                <action android:name="android.app.action.DEVICE_ADMIN_ENABLED" />
+                <action android:name="android.app.action.DEVICE_ADMIN_DISABLED" />
+            </intent-filter>
+        </receiver>
     </application>
 </manifest>

--- a/service/src/main/java/com/amazmod/service/AdminReceiver.java
+++ b/service/src/main/java/com/amazmod/service/AdminReceiver.java
@@ -1,0 +1,24 @@
+package com.amazmod.service;
+
+import android.app.admin.DeviceAdminReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.support.v4.content.LocalBroadcastManager;
+
+public class AdminReceiver extends DeviceAdminReceiver {
+    public static final String ACTION_DISABLED = "device_admin_action_disabled";
+    public static final String ACTION_ENABLED = "device_admin_action_enabled";
+
+    @Override
+    public void onDisabled(Context context, Intent intent) {
+        super.onDisabled(context, intent);
+        LocalBroadcastManager.getInstance(context).sendBroadcast(
+                new Intent(ACTION_DISABLED));
+    }
+    @Override
+    public void onEnabled(Context context, Intent intent) {
+        super.onEnabled(context, intent);
+        LocalBroadcastManager.getInstance(context).sendBroadcast(
+                new Intent(ACTION_ENABLED));
+    }
+}

--- a/service/src/main/java/com/amazmod/service/Constants.java
+++ b/service/src/main/java/com/amazmod/service/Constants.java
@@ -34,6 +34,7 @@ public class Constants {
     public static final String PREF_DISABLE_NOTIFICATIONS_SCREENON = "pref_notification_screenon";
     public static final String PREF_SHAKE_TO_DISMISS_GRAVITY = "pref_shake_to_dismiss_gravity";
     public static final String PREF_SHAKE_TO_DISMISS_NUM_OF_SHAKES = "pref_shake_to_dismiss_num_of_shakes";
+    public static final String PREF_PHONE_CONNECTION_ALERT = "phone_connection_alert";
 
     public static final int PREF_DEFAULT_NOTIFICATION_SCREEN_TIMEOUT = 10 * 1000;
     public static final int PREF_DEFAULT_NOTIFICATION_VIBRATION = 350;

--- a/service/src/main/java/com/amazmod/service/MainService.java
+++ b/service/src/main/java/com/amazmod/service/MainService.java
@@ -2,14 +2,20 @@ package com.amazmod.service;
 
 import android.app.Service;
 import android.content.BroadcastReceiver;
+import android.content.ContentResolver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.database.ContentObserver;
+import android.net.Uri;
 import android.os.BatteryManager;
+import android.os.Handler;
 import android.os.IBinder;
+import android.os.Vibrator;
 import android.provider.Settings;
 import android.support.annotation.Nullable;
 import android.util.Log;
+import android.widget.Toast;
 
 import com.amazmod.service.events.HardwareButtonEvent;
 import com.amazmod.service.events.NightscoutDataEvent;
@@ -28,6 +34,7 @@ import com.amazmod.service.notifications.NotificationService;
 import com.amazmod.service.notifications.NotificationsReceiver;
 import com.amazmod.service.settings.SettingsManager;
 import com.amazmod.service.springboard.WidgetSettings;
+import com.amazmod.service.ui.PhoneConnectionActivity;
 import com.amazmod.service.util.DeviceUtil;
 import com.amazmod.service.util.FileDataFactory;
 import com.amazmod.service.util.SystemProperties;
@@ -102,6 +109,7 @@ public class MainService extends Service implements Transporter.DataListener {
     private DataBundle dataBundle;
 
     private SlptClockClient slptClockClient;
+    private ContentObserver phoneConnectionObserver;
 
     @Override
     public void onCreate() {
@@ -163,6 +171,31 @@ public class MainService extends Service implements Transporter.DataListener {
         });
 
         setupHardwareKeysMusicControl(settingsManager.getBoolean(Constants.PREF_ENABLE_HARDWARE_KEYS_MUSIC_CONTROL, false));
+
+        //Register phone connect/disconnect monitor
+        ContentResolver contentResolver = getContentResolver();
+        Uri setting = Settings.System.getUriFor("com.huami.watch.extra.DEVICE_CONNECTION_STATUS");
+        phoneConnectionObserver = new ContentObserver(new Handler()) {
+            @Override
+            public void onChange(boolean selfChange) {
+                super.onChange(selfChange);
+                if(true){//Settings could go here
+                    // Show connection status
+                    Intent intent = new Intent(context, PhoneConnectionActivity.class);
+                    intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK |
+                            Intent.FLAG_ACTIVITY_NEW_DOCUMENT |
+                            Intent.FLAG_ACTIVITY_CLEAR_TOP |
+                            Intent.FLAG_ACTIVITY_MULTIPLE_TASK);
+                    context.startActivity(intent);
+                }
+            }
+
+            @Override
+            public boolean deliverSelfNotifications() {
+                return true;
+            }
+        };
+        contentResolver.registerContentObserver(setting, false, phoneConnectionObserver);
     }
 
     @Override
@@ -173,6 +206,9 @@ public class MainService extends Service implements Transporter.DataListener {
             unregisterReceiver(notificationsReceiver);
             notificationsReceiver = null;
         }
+
+        // Unregister phone connection observer
+        getContentResolver().unregisterContentObserver(phoneConnectionObserver);
 
         super.onDestroy();
     }

--- a/service/src/main/java/com/amazmod/service/MainService.java
+++ b/service/src/main/java/com/amazmod/service/MainService.java
@@ -1,6 +1,7 @@
 package com.amazmod.service;
 
 import android.app.Service;
+import android.app.admin.DeviceAdminReceiver;
 import android.content.BroadcastReceiver;
 import android.content.ContentResolver;
 import android.content.Context;

--- a/service/src/main/java/com/amazmod/service/MainService.java
+++ b/service/src/main/java/com/amazmod/service/MainService.java
@@ -179,7 +179,7 @@ public class MainService extends Service implements Transporter.DataListener {
             @Override
             public void onChange(boolean selfChange) {
                 super.onChange(selfChange);
-                if(true){//Settings could go here
+                if(settingsManager.getBoolean(Constants.PREF_PHONE_CONNECTION_ALERT,false)){//Settings go here
                     // Show connection status
                     Intent intent = new Intent(context, PhoneConnectionActivity.class);
                     intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK |

--- a/service/src/main/java/com/amazmod/service/settings/SettingsManager.java
+++ b/service/src/main/java/com/amazmod/service/settings/SettingsManager.java
@@ -32,6 +32,7 @@ public class SettingsManager {
         editor.putBoolean(Constants.PREF_DISABLE_NOTIFICATIONS_SCREENON, settingsData.isDisableNotificationsScreenOn());
         editor.putInt(Constants.PREF_SHAKE_TO_DISMISS_GRAVITY, settingsData.getShakeToDismissGravity());
         editor.putInt(Constants.PREF_SHAKE_TO_DISMISS_NUM_OF_SHAKES, settingsData.getShakeToDismissNumOfShakes());
+        editor.putBoolean(Constants.PREF_PHONE_CONNECTION_ALERT, settingsData.isPhoneConnectionAlert());
 
         editor.apply();
     }

--- a/service/src/main/java/com/amazmod/service/ui/NotificationActivity.java
+++ b/service/src/main/java/com/amazmod/service/ui/NotificationActivity.java
@@ -1,12 +1,15 @@
 package com.amazmod.service.ui;
 
 import android.app.Activity;
+import android.app.admin.DevicePolicyManager;
+import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.os.Bundle;
 import android.os.Handler;
+import android.os.PowerManager;
 import android.os.Vibrator;
 import android.provider.Settings;
 import android.util.Log;
@@ -18,12 +21,14 @@ import android.widget.Button;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import com.amazmod.service.Constants;
 import com.amazmod.service.R;
 import com.amazmod.service.events.ReplyNotificationEvent;
 import com.amazmod.service.settings.SettingsManager;
 import com.amazmod.service.support.ActivityFinishRunnable;
+import com.amazmod.service.AdminReceiver;
 import com.amazmod.service.util.DeviceUtil;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
@@ -69,6 +74,7 @@ public class NotificationActivity extends Activity {
     private static float fontSizeSP;
     private static int screenMode;
     private static int screenBrightness = 999989;
+    private static boolean deviceWasLocked;
     private Context mContext;
 
     private NotificationData notificationSpec;
@@ -96,6 +102,8 @@ public class NotificationActivity extends Activity {
 
         notificationSpec = getIntent().getParcelableExtra(NotificationData.EXTRA);
 
+        deviceWasLocked = DeviceUtil.isDeviceLocked(getBaseContext());
+
         boolean hideReplies;
 
         //Load preferences
@@ -109,7 +117,7 @@ public class NotificationActivity extends Activity {
         setWindowFlags(true);
 
         //Do not activate screen if it is disabled in settings and screen is off
-        if (disableNotificationsScreenOn && DeviceUtil.isDeviceLocked(getBaseContext())) {
+        if (disableNotificationsScreenOn && deviceWasLocked) {
             setScreenModeOff(true);
         }
 
@@ -276,6 +284,32 @@ public class NotificationActivity extends Activity {
                     }
                 }
             }, 10000 - notificationSpec.getTimeoutRelock() + 600);
+        }
+
+        if(deviceWasLocked){
+            Log.i(Constants.TAG, "NotificationActivity device was locked, locking again...");
+            lock();
+        }
+    }
+
+    private void lock() {
+        PowerManager pm = (PowerManager)getSystemService(Context.POWER_SERVICE);
+        if (pm.isScreenOn()) {
+            DevicePolicyManager policy = (DevicePolicyManager)
+                    getSystemService(Context.DEVICE_POLICY_SERVICE);
+            try {
+                policy.lockNow();
+            } catch (SecurityException ex) {
+                Toast.makeText(
+                        this,
+                        "must enable device administrator",
+                        Toast.LENGTH_LONG).show();
+                ComponentName admin = new ComponentName(mContext, AdminReceiver.class);
+                Intent intent = new Intent(
+                        DevicePolicyManager.ACTION_ADD_DEVICE_ADMIN).putExtra(
+                        DevicePolicyManager.EXTRA_DEVICE_ADMIN, admin);
+                mContext.startActivity(intent);
+            }
         }
     }
 

--- a/service/src/main/java/com/amazmod/service/ui/PhoneConnectionActivity.java
+++ b/service/src/main/java/com/amazmod/service/ui/PhoneConnectionActivity.java
@@ -1,0 +1,111 @@
+package com.amazmod.service.ui;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.os.Bundle;
+import android.os.Handler;
+import android.os.Vibrator;
+import android.provider.Settings;
+import android.util.Log;
+import android.util.TypedValue;
+import android.view.MotionEvent;
+import android.view.View;
+import android.view.WindowManager;
+import android.widget.Button;
+import android.widget.ImageView;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+
+import com.amazmod.service.Constants;
+import com.amazmod.service.R;
+import com.amazmod.service.events.ReplyNotificationEvent;
+import com.amazmod.service.settings.SettingsManager;
+import com.amazmod.service.support.ActivityFinishRunnable;
+import com.amazmod.service.util.DeviceUtil;
+import com.google.gson.Gson;
+import com.google.gson.reflect.TypeToken;
+
+import java.lang.reflect.Type;
+import java.util.ArrayList;
+import java.util.List;
+
+import amazmod.com.models.Reply;
+import amazmod.com.transport.data.NotificationData;
+import butterknife.BindView;
+import butterknife.ButterKnife;
+import butterknife.OnClick;
+import xiaofei.library.hermeseventbus.HermesEventBus;
+
+public class PhoneConnectionActivity extends Activity {
+
+    @BindView(R.id.description)
+    TextView text;
+    @BindView(R.id.icon)
+    ImageView icon;
+    private Handler handler;
+    private ActivityFinishRunnable activityFinishRunnable;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        setContentView(R.layout.icon_overlay);
+
+        ButterKnife.bind(this);
+
+        if(android.provider.Settings.System.getString(getContentResolver(), "com.huami.watch.extra.DEVICE_CONNECTION_STATUS").equals("0")){
+            // Phone disconnected
+            // Wake screen and trow overlay here
+            icon.setImageDrawable(getDrawable(R.drawable.ic_outline_phonelink_erase));
+            text.setText(getString(R.string.phone_disconnected));
+        }else{
+            // Phone connected
+            // Wake screen and trow overlay here
+            icon.setImageDrawable(getDrawable(R.drawable.ic_outline_phonelink_ring));
+            text.setText(getString(R.string.phone_connected));
+        }
+
+        handler = new Handler();
+        activityFinishRunnable = new ActivityFinishRunnable(this);
+        startTimerFinish();
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        //ShakeDetector.start();
+    }
+
+    @Override
+    protected void onStop() {
+        super.onStop();
+        //ShakeDetector.stop();
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        //ShakeDetector.destroy();
+    }
+
+    private void startTimerFinish() {
+        // Vibrate
+        try {
+            ((Vibrator) getSystemService(VIBRATOR_SERVICE)).vibrate(1000);
+        } catch (Exception ex) {
+            ex.printStackTrace();
+        }
+
+        handler.removeCallbacks(activityFinishRunnable);
+        handler.postDelayed(activityFinishRunnable, 3*1000);
+    }
+
+    @Override
+    public void finish() {
+        handler.removeCallbacks(activityFinishRunnable);
+        super.finish();
+    }
+}

--- a/service/src/main/java/com/amazmod/service/ui/PhoneConnectionActivity.java
+++ b/service/src/main/java/com/amazmod/service/ui/PhoneConnectionActivity.java
@@ -56,6 +56,8 @@ public class PhoneConnectionActivity extends Activity {
 
         ButterKnife.bind(this);
 
+        setWindowFlags(true);
+
         if(android.provider.Settings.System.getString(getContentResolver(), "com.huami.watch.extra.DEVICE_CONNECTION_STATUS").equals("0")){
             // Phone disconnected
             // Wake screen and trow overlay here
@@ -106,6 +108,22 @@ public class PhoneConnectionActivity extends Activity {
     @Override
     public void finish() {
         handler.removeCallbacks(activityFinishRunnable);
+        setWindowFlags(false);
         super.finish();
+    }
+
+    private void setWindowFlags(boolean enable) {
+
+        final int flags = WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED |
+                WindowManager.LayoutParams.FLAG_DISMISS_KEYGUARD |
+                WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON |
+                WindowManager.LayoutParams.FLAG_ALLOW_LOCK_WHILE_SCREEN_ON |
+                WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON;
+
+        if (enable) {
+            getWindow().addFlags(flags);
+        } else {
+            getWindow().clearFlags(flags);
+        }
     }
 }

--- a/service/src/main/res/drawable/ic_outline_phonelink_erase.xml
+++ b/service/src/main/res/drawable/ic_outline_phonelink_erase.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M13,8.2l-1,-1l-4,4l-4,-4l-1,1l4,4l-4,4l1,1l4,-4l4,4l1,-1l-4,-4L13,8.2zM19,1H9C7.9,1 7,1.9 7,3v3h2V4h10v16H9v-2H7v3c0,1.1 0.9,2 2,2h10c1.1,0 2,-0.9 2,-2V3C21,1.9 20.1,1 19,1z"/>
+</vector>

--- a/service/src/main/res/drawable/ic_outline_phonelink_ring.xml
+++ b/service/src/main/res/drawable/ic_outline_phonelink_ring.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M20.1,7.7l-1,1c1.8,1.8 1.8,4.6 0,6.5l1,1C22.6,13.9 22.6,10.1 20.1,7.7zM18,9.8l-1,1c0.5,0.7 0.5,1.6 0,2.3l1,1C19.2,12.9 19.2,11.1 18,9.8zM14,1H4C2.9,1 2,1.9 2,3v18c0,1.1 0.9,2 2,2h10c1.1,0 2,-0.9 2,-2V3C16,1.9 15.1,1 14,1zM14,20H4V4h10V20z"/>
+</vector>

--- a/service/src/main/res/layout/icon_overlay.xml
+++ b/service/src/main/res/layout/icon_overlay.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.widget.RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/white">
+
+    <ImageView
+        android:id="@+id/icon"
+        android:layout_width="32dp"
+        android:layout_height="32dp"
+        android:layout_alignParentTop="true"
+        android:layout_centerHorizontal="true"
+        android:layout_marginTop="75dp"
+        app:srcCompat="@drawable/ic_outline_phonelink_erase" />
+
+    <TextView
+        android:id="@+id/description"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_below="@+id/icon"
+        android:layout_centerHorizontal="true"
+        android:layout_weight="1"
+        android:text="@string/phone_disconnected"
+        android:textColor="#000000"/>
+
+</android.widget.RelativeLayout>

--- a/service/src/main/res/values/strings.xml
+++ b/service/src/main/res/values/strings.xml
@@ -6,4 +6,6 @@
     <string name="last_charge_no_info">Waiting for data</string>
     <string name="close">Close&#160;&#160;</string>
     <string name="replies">&#160;&#160;Replies</string>
+    <string name="phone_disconnected">Phone disconnected</string>
+    <string name="phone_connected">Phone connected</string>
 </resources>

--- a/service/src/main/res/values/strings.xml
+++ b/service/src/main/res/values/strings.xml
@@ -8,4 +8,6 @@
     <string name="replies">&#160;&#160;Replies</string>
     <string name="phone_disconnected">Phone disconnected</string>
     <string name="phone_connected">Phone connected</string>
+    <string name="device_admin">device_admin</string>
+    <string name="device_admin_description">Grand lock screen access</string>
 </resources>

--- a/service/src/main/res/xml/device_admin.xml
+++ b/service/src/main/res/xml/device_admin.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<device-admin xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-policies>
+        <force-lock />
+    </uses-policies>
+</device-admin>

--- a/transport/src/main/java/amazmod/com/transport/data/SettingsData.java
+++ b/transport/src/main/java/amazmod/com/transport/data/SettingsData.java
@@ -23,6 +23,7 @@ public class SettingsData extends Transportable implements Parcelable {
     public static final String DISABLE_NOTIFICATION_SCREENON = "disable_notification_screenon";
     public static final String SHAKE_TO_DISMISS_GRAVITY = "shake_to_dismiss_gravity";
     public static final String SHAKE_TO_DISMISS_NUM_OF_SHAKES = "shake_to_dismiss_num_of_shakes";
+    public static final String PHONE_CONNECTION_ALERT = "phone_connection_alert";
 
     private String replies;
     private int vibration;
@@ -36,6 +37,7 @@ public class SettingsData extends Transportable implements Parcelable {
     private boolean disableNotificationsScreenOn;
     private int shakeToDismissGravity;
     private int shakeToDismissNumOfShakes;
+    private boolean phoneConnectionAlert;
 
     public SettingsData() {
     }
@@ -53,6 +55,7 @@ public class SettingsData extends Transportable implements Parcelable {
         disableNotificationsScreenOn = in.readByte() != 0;
         shakeToDismissGravity = in.readInt();
         shakeToDismissNumOfShakes = in.readInt();
+        phoneConnectionAlert = in.readByte() != 0;
     }
 
     public static final Creator<SettingsData> CREATOR = new Creator<SettingsData>() {
@@ -81,6 +84,7 @@ public class SettingsData extends Transportable implements Parcelable {
         dataBundle.putBoolean(DISABLE_NOTIFICATION_SCREENON, disableNotificationsScreenOn);
         dataBundle.putInt(SHAKE_TO_DISMISS_GRAVITY, shakeToDismissGravity);
         dataBundle.putInt(SHAKE_TO_DISMISS_NUM_OF_SHAKES, shakeToDismissNumOfShakes);
+        dataBundle.putBoolean(PHONE_CONNECTION_ALERT, phoneConnectionAlert);
 
         return dataBundle;
     }
@@ -100,6 +104,7 @@ public class SettingsData extends Transportable implements Parcelable {
         settingsData.setDisableNotificationScreenOn(dataBundle.getBoolean(DISABLE_NOTIFICATION_SCREENON));
         settingsData.setShakeToDismissGravity(dataBundle.getInt(SHAKE_TO_DISMISS_GRAVITY));
         settingsData.setShakeToDismissNumOfShakes(dataBundle.getInt(SHAKE_TO_DISMISS_NUM_OF_SHAKES));
+        settingsData.setPhoneConnectionAlert(dataBundle.getBoolean(PHONE_CONNECTION_ALERT));
 
         return settingsData;
     }
@@ -207,6 +212,14 @@ public class SettingsData extends Transportable implements Parcelable {
         this.shakeToDismissNumOfShakes = shakeToDismissNumOfShakes;
     }
 
+    public boolean isPhoneConnectionAlert() {
+        return phoneConnectionAlert;
+    }
+
+    public void setPhoneConnectionAlert(boolean phoneConnectionAlert) {
+        this.phoneConnectionAlert = phoneConnectionAlert;
+    }
+
     @Override
     public int describeContents() {
         return 0;
@@ -226,5 +239,6 @@ public class SettingsData extends Transportable implements Parcelable {
         dest.writeByte((byte) (disableNotificationsScreenOn ? 1 : 0));
         dest.writeInt(shakeToDismissGravity);
         dest.writeInt(shakeToDismissNumOfShakes);
+        dest.writeByte((byte) (phoneConnectionAlert ? 1 : 0));
     }
 }


### PR DESCRIPTION
Phone connected/disconnected alert:
- Added in settings too (default off)
- Bug: Show time is 4 sec but it takes some time to start so it is less
- Bug: vibration runs before the activity is shown

Watchface settings:
- Fixed some crashes errors in the receiver
- Fixed next phone alarm value

Lock screen after Custom UI notification:
- Added device admin support
- If locked before + admin, then locks the screen
- Needs Amazmod to be device admin, see Issue #180 